### PR TITLE
fedora patch to allow build with distribution optflags

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -1,10 +1,22 @@
 env = Environment()
 
+AddOption( "--optflags",
+           dest="optflags",
+           type="string",
+           nargs=1,
+           action="store",
+           help="set custom optflags")
+
+optflags = GetOption("optflags")
+
+
 debug = ARGUMENTS.get('debug', 0)
 
 if int(debug):
     env.Append(CPPFLAGS = ['-g', '-Wall', '-O0', '-finline-functions',
                            '-Wno-write-strings', '-DHAVE_LIBXPM'])
+else if optflags:
+    env.Append( CPPFLAGS = optflags )
 else:
     env.Append(CPPFLAGS = ['-O6', '-funroll-loops',
                            '-fomit-frame-pointer',


### PR DESCRIPTION
Now that 2.3.2 is released, I try to upstream this old fedora patch that seems useful