### PR TITLE
Fix progressbar

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -634,7 +634,7 @@ int SARLoadProgressCB(void *ptr, long pos, long size)
 			cb_data->coeff_offset +
 			    ((float)pos / (float)size *
 			    cb_data->coeff_range),
-			True		/* Redraw */
+			False		/* Redraw */
 		    );
 		    break;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -597,6 +597,12 @@ int SARLoadProgressCB(void *ptr, long pos, long size)
 	void *o;
 	gw_display_struct *display;
 	sar_progress_cb_struct *cb_data = SAR_PROGRESS_CB(ptr);
+
+	// Update progress in 10% increments. Otherwise the progress bar
+	// is updated so much that it makes loading itself 10x longer.
+	if ((pos % (size / 10)) != 0)
+	    return(0);
+
 	if(cb_data == NULL)
 	    return(0);
 
@@ -634,7 +640,7 @@ int SARLoadProgressCB(void *ptr, long pos, long size)
 			cb_data->coeff_offset +
 			    ((float)pos / (float)size *
 			    cb_data->coeff_range),
-			False		/* Redraw */
+			True		/* Redraw */
 		    );
 		    break;
 		}


### PR DESCRIPTION
 Disable progressbar redraw

On nowadays systems, the game load in less than one second.
Disabling this redraw removes the flickering and makes game start much faster