### PR TITLE
Hoist now waits for door to be fully opened before going out

### DIFF
--- a/src/obj.h
+++ b/src/obj.h
@@ -465,6 +465,7 @@ typedef struct {
 #define SAR_OBJ_PART_FLAG_DOOR_STAY_OPEN	(1 << 5)	/* Do not close door on
 								 * next loop check,
 								 * ie if door was opened by player explicitly */
+#define SAR_OBJ_PART_FLAG_DOOR_OPENED	(1 << 6)	/* True if fully opened */
 /* Landing Gears */
 #define SAR_OBJ_PART_FLAG_LGEAR_FIXED	(1 << 3)	/* Always down */
 #define SAR_OBJ_PART_FLAG_LGEAR_DAMAGED	(1 << 4)

--- a/src/simop.c
+++ b/src/simop.c
@@ -3409,54 +3409,54 @@ void SARSimApplyGCTL(sar_core_struct *core_ptr, sar_object_struct *obj_ptr)
 		    }
 
 		    /* Is door fully opened ? */
-			if (door_ptr->flags & SAR_OBJ_PART_FLAG_DOOR_OPENED)
-			{
-		    /* Was rope previously in? */
-		    if(hoist->rope_cur < hoist->contact_z_max)
+		    if (door_ptr->flags & SAR_OBJ_PART_FLAG_DOOR_OPENED)
 		    {
-			/* Hoist deployment was in so now it needs to
-			 * be put out and its values initialized
-			 */
-			sar_position_struct	*hoist_pos = &hoist->pos,
+			/* Was rope previously in? */
+			if(hoist->rope_cur < hoist->contact_z_max)
+			{
+			    /* Hoist deployment was in so now it needs to
+			    * be put out and its values initialized
+			    */
+			    sar_position_struct	*hoist_pos = &hoist->pos,
 						*hoist_offset = &hoist->offset;
-			double	tx = hoist_offset->x,
+			    double	tx = hoist_offset->x,
 				ty = hoist_offset->y,
 				tz = hoist_offset->z;
 
-			/* Move to initial position at hoist center */
-			SFMOrthoRotate2D(
-			    obj_ptr->dir.heading, &tx, &ty
-			);
-			hoist_pos->x = (float)(
-			    obj_ptr->pos.x + tx
-			);
-			hoist_pos->y = (float)(
-			    obj_ptr->pos.y + ty
-			);
-			hoist_pos->z = (float)(
-			    obj_ptr->pos.z + tz -
-			    hoist->rope_cur
-			);
+			    /* Move to initial position at hoist center */
+			    SFMOrthoRotate2D(
+				obj_ptr->dir.heading, &tx, &ty
+			    );
+			    hoist_pos->x = (float)(
+				obj_ptr->pos.x + tx
+			    );
+			    hoist_pos->y = (float)(
+				obj_ptr->pos.y + ty
+			    );
+			    hoist_pos->z = (float)(
+				obj_ptr->pos.z + tz -
+				hoist->rope_cur
+			    );
 
-			/* Reset hoist values */
-			hoist->rope_cur = hoist->contact_z_max;
-			hoist->rope_cur_vis = hoist->rope_cur;
-			hoist->on_ground = 0;
-		    }
-		    else
-		    {
-			/* Lower rope normally */
-			hoist->rope_cur += (rope_rate *
-			    time_compensation * time_compression *
-			    hoist_down_coeff);
-			if(hoist->rope_cur > hoist->rope_max)
-			    hoist->rope_cur = hoist->rope_max;
-
-			/* Do not update rope_cur_vis, it will be updated
-			 * in the other simulation calls
-			 */
-		    }
+			    /* Reset hoist values */
+			    hoist->rope_cur = hoist->contact_z_max;
+			    hoist->rope_cur_vis = hoist->rope_cur;
+			    hoist->on_ground = 0;
 			}
+			else
+			{
+			    /* Lower rope normally */
+			    hoist->rope_cur += (rope_rate *
+				time_compensation * time_compression *
+				hoist_down_coeff);
+			    if(hoist->rope_cur > hoist->rope_max)
+				hoist->rope_cur = hoist->rope_max;
+
+			    /* Do not update rope_cur_vis, it will be updated
+			    * in the other simulation calls
+			    */
+			}
+		    }
 		}
 	    }
 	}

--- a/src/simop.c
+++ b/src/simop.c
@@ -3366,7 +3366,7 @@ void SARSimApplyGCTL(sar_core_struct *core_ptr, sar_object_struct *obj_ptr)
 				        scene,
 				        &core_ptr->object, &core_ptr->total_objects,
 				        obj_ptr,
-				        0	/* Close */
+				        door_ptr->flags & !SAR_OBJ_PART_FLAG_STATE	/* Close */
 				    );
 			    }
 			}	/* Was rope previously out? */
@@ -3388,7 +3388,7 @@ void SARSimApplyGCTL(sar_core_struct *core_ptr, sar_object_struct *obj_ptr)
 			    scene,
 			    &core_ptr->object, &core_ptr->total_objects,
 			    obj_ptr,
-			    1		/* Open */
+			    door_ptr->flags | SAR_OBJ_PART_FLAG_STATE		/* Open */
 			);
 
 			/* Here is also a good point to check if we have
@@ -3408,6 +3408,9 @@ void SARSimApplyGCTL(sar_core_struct *core_ptr, sar_object_struct *obj_ptr)
 			}
 		    }
 
+		    /* Is door fully opened ? */
+			if (door_ptr->flags & SAR_OBJ_PART_FLAG_DOOR_OPENED)
+			{
 		    /* Was rope previously in? */
 		    if(hoist->rope_cur < hoist->contact_z_max)
 		    {
@@ -3453,6 +3456,7 @@ void SARSimApplyGCTL(sar_core_struct *core_ptr, sar_object_struct *obj_ptr)
 			 * in the other simulation calls
 			 */
 		    }
+			}
 		}
 	    }
 	}

--- a/src/simutils.c
+++ b/src/simutils.c
@@ -649,12 +649,15 @@ void SARSimUpdatePart(
 
 		/* Already opened? */
 		if(part_ptr->anim_pos == (sar_grad_anim_t)-1)
+		{
+			part_ptr->flags |= SAR_OBJ_PART_FLAG_DOOR_OPENED; /* set "door fully opened" */
 		    break;
+		}
 
 		/* Door fixed and cannot be opened? */
 		if(flags & SAR_OBJ_PART_FLAG_DOOR_FIXED)
 		    break;
-
+		
 		prev_pos = part_ptr->anim_pos;
 
 		/* Increase animation position value */
@@ -684,6 +687,8 @@ void SARSimUpdatePart(
 		/* Door already closed? */
 		if(part_ptr->anim_pos == 0)
 		    break;
+		else
+			part_ptr->flags &= !SAR_OBJ_PART_FLAG_DOOR_OPENED; /* reset "door fully opened" */
 
 		/* Door fixed and cannot be closed? */
 		if(flags & SAR_OBJ_PART_FLAG_DOOR_FIXED)


### PR DESCRIPTION
When player was lowering hoist, hoist was going out before door was fully opened. Now, when player lowers hoist, door opens fully first, then hoist goes out.