### PR TITLE
Redraw menus to avoid black windows when exiting simulations

### DIFF
--- a/src/sarmenuop.c
+++ b/src/sarmenuop.c
@@ -203,11 +203,16 @@ void SARMenuSwitchToMenu(sar_core_struct *core_ptr, const char *name)
 		m->selected_object = 0;
 
 		/* Update index number of the current menu */
-	        core_ptr->cur_menu = new_menu_num;
+		core_ptr->cur_menu = new_menu_num;
+
+		/* Redraw current menu */
+		SARMenuDrawAll(display, m);
+		GWSwapBuffer(display);
 	    }
 
 	    /* Redraw */
 	    GWPostRedraw(display);
+
 
 	    /* Mark input as ready */
 	    GWSetInputReady(display);


### PR DESCRIPTION
I had "fully black menus" when exiting simulation (ESC key) in free flight and missions: menus were only redrawn when mouse cursor moves over a button. This modification solves that by calling an existing redraw routine.
My graphic system:
AMD Radeon RX 5600 XT (NAVI10, DRM 3.40.0, 5.10.75-desktop-1.mga8, LLVM 11.0.1)
OpenGL core profile version string: 4.6 (Core Profile) Mesa 21.2.4