### PR TITLE
Fix last item never shown in menu lists.

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -3591,12 +3591,12 @@ static void SARMenuDoDrawObject(
 		NULL, NULL,
 		&fw, &fh
 	    );
-	    /* Calculate items visible, remember to subtract three
+	    /* Calculate items visible, remember to subtract four
 	     * items for borders and heading.
 	     */
 	    if(fh > 0)
 		items_visable = MAX(
-		    (h / fh) - 3,
+		    (h / fh) - 4,
 		    0
 		);
 	    else  


### PR DESCRIPTION
I just saw that **in menu lists** (missions, free flight locations, and so on...) **last item was never shown** because of available vertical space bad calculation.
I saw it because in corsica scenery free flight, last registered location in corsica.scn (which is Rizzanese/Zoza reservoir) was not visible in menu list.
This fix it.