### PR TITLE
Fix AGL altitude calculation for fixed landing gears and reorganize t…

### DIFF
--- a/src/sardraw.c
+++ b/src/sardraw.c
@@ -3791,31 +3791,23 @@ static void SARDrawOutsideAttitude(
 	    y += 18;
 
 	    /* Altitude AGL */
+	    if(aircraft->landed)
+		v1 = 0.0f;
+	    else
+		v1 = (float)MAX(
+		    -(((((gear_state == 1) || (gear_state == 2)) ? aircraft->gear_height : 0.0f) +
+		    aircraft->belly_height) +
+		    aircraft->center_to_ground_height), 0.0f
+		);
 	    switch(opt->units)
 	    {
 	      case SAR_UNITS_METRIC:
-		if(aircraft->landed)
-		  v1 = 0.0f;
-		else
-		  v1 = (float)MAX(
-		    -((((gear_state == 1) ? aircraft->gear_height : 0.0f) +
-		    aircraft->belly_height) +
-		    aircraft->center_to_ground_height), 0.0f
-		  );
 		units_str1 = "M";
 		break;
+
 	      case SAR_UNITS_METRIC_ALT_FEET:
 	      default:
-		if(aircraft->landed)
-		  v1 = 0.0f;
-		else
-		  v1 = (float)SFMMetersToFeet(
-		   MAX(
-		    -((((gear_state == 1) ? aircraft->gear_height : 0.0f) +
-		    aircraft->belly_height) +
-		    aircraft->center_to_ground_height), 0.0f
-		   )
-		  );
+		v1 = (float)SFMMetersToFeet(v1);
 		units_str1 = "FT";
 		break;
 	    }


### PR DESCRIPTION
…his code a little bit.

**AGL altitude calculation** when landing is actually **wrong for aircrafts with fixed landing gear**: it's visible because when a such helicopter lands, **AGL altitude** gradually decreases, then **suddenly drops to zero**. This fix it.

**Remarks**:
- In `v1` distance calculation, I added `gear_state == 2` which means landing gear "down/deployed/out and fixed". _This gear state was already defined_ in SARSimOpLandingGear(...) in simutils.c, lines 917 to 923.
-  Of course instead of `(gear_state == 1) || (gear_state == 2)` it is possible to write `gear_state >= 1` but I think that it is less clear, and more risky if a new gear state is added later.
- Regarding code reorganization, I think that it makes more sense now: first, calculate the value, then, convert it to the right unit.
- At take off, whatever landing gear type, AGL altitude suddently jumps from zero to 0.3m (~ 1.0ft): this is because of sfmsimforce.c, line 1635.