### PR TITLE
Better water detection on altitude lakes.

### DIFF
--- a/src/sardraw.c
+++ b/src/sardraw.c
@@ -7999,8 +7999,9 @@ void SARDrawMap(
 	if(opt->textured_objects)
 	{
 	    /* Enable alpha testing and turn on GL_TEXTURE_2D */
+	    /* If ground texture opacity is lower or equal to 99%, ground will be considered as water */
 	    StateGLEnable(state, GL_ALPHA_TEST);
-	    StateGLAlphaFunc(state, GL_GREATER, 0.5);
+	    StateGLAlphaFunc(state, GL_GREATER, 0.99);
 
 	    SAR_DRAW_TEXTURE_2D_ON
 	}


### PR DESCRIPTION
For now, water detection works good at sea level, but it is difficult for altitude water bodies:
- If water surface is made with a full black (0x000000) color, surface becomes invisible and player can see through it up to sea level.
- If water surface is made with alpha channel at 50% opacity, it is always possible to see through surface. By setting transparency detection at at least 99% opacity, surface is detected as water but it is not possible to anything trough it. Result can be checked on any altitude body of Corsica scenery update.