### PR TITLE
Fix #44: ghosting on intel. GL_LINES_ADJACENCY errors.

### DIFF
--- a/src/obj.h
+++ b/src/obj.h
@@ -26,7 +26,7 @@
 #include "sfm.h"
 #include "v3dtex.h"
 #include "sound.h"
-
+#include <GL/gl.h>
 
 /*
  *	Object Flags Type:
@@ -146,7 +146,7 @@ typedef struct {
 	char		*filename;	/* Can be NULL */
 	char		*name;		/* Can be NULL */
 
-	void		*data;		/* A GLuint referencing a GL list */
+	GLuint		data;		/* A GLuint referencing a GL list */
 
 	/* Statistics */
 	unsigned long	mem_size;	/* Memory size, in bytes */

--- a/src/objio.c
+++ b/src/objio.c
@@ -746,7 +746,7 @@ sar_visual_model_struct *SARObjLoadX3DDataVisualModel(
 	/* New visual model must not be shared */
 	if(SARVisualModelGetRefCount(vmodel) == 1)
 	{
-	    GLuint list = (GLuint)SARVisualModelNewList(vmodel);
+	    GLuint list = SARVisualModelNewList(vmodel);
 	    if(list != 0)
 	    {
 		vmodel->load_state = SAR_VISUAL_MODEL_LOADING;
@@ -1805,7 +1805,7 @@ int SARObjLoadHeightField(
 		&num_grids_x, &num_grids_y,	/* Number of grids */
 		&grid_space_x, &grid_space_y,	/* Grid spacing in meters */
 		&zpoints,			/* Heightfield points return */
-		(void *)list,			/* GL display list */
+		list,			/* GL display list */
 		&hfopt
 	    );
 	    if(status)

--- a/src/objutils.c
+++ b/src/objutils.c
@@ -95,7 +95,7 @@ sar_visual_model_struct *SARVisualModelNew(
 	sar_scene_struct *scene,
 	const char *filename, const char *name
 );
-void *SARVisualModelNewList(sar_visual_model_struct *vmodel);
+GLuint SARVisualModelNewList(sar_visual_model_struct *vmodel);
 int SARVisualModelGetRefCount(sar_visual_model_struct *vmodel);  
 void SARVisualModelRef(sar_visual_model_struct *vmodel);
 void SARVisualModelUnref(
@@ -816,7 +816,7 @@ sar_visual_model_struct *SARVisualModelNew(
 	    vmodel->filename = STRDUP(filename);
 	    vmodel->name = STRDUP(name);
 
-	    vmodel->data = NULL;
+	    vmodel->data = 0;
 
 	    vmodel->mem_size = 0;
 	    vmodel->statements = 0;
@@ -832,15 +832,15 @@ sar_visual_model_struct *SARVisualModelNew(
  *	The return value is really a GLuint (not a void *), can return
  *	NULL on failure.
  */
-void *SARVisualModelNewList(sar_visual_model_struct *vmodel)
+GLuint SARVisualModelNewList(sar_visual_model_struct *vmodel)
 {
 	GLuint list;
 
 	if(vmodel == NULL)
-	    return(NULL);
+	    return 0;
 
 	/* Get existing GL display list if any */
-	list = (GLuint)vmodel->data;
+	list = vmodel->data;
 	if(list > 0)
 	{
 	    /* Already has an allocated GL display list so delete it
@@ -848,7 +848,7 @@ void *SARVisualModelNewList(sar_visual_model_struct *vmodel)
 	     */
 	    glDeleteLists(list, 1);
 	    list = 0;
-	    vmodel->data = NULL;
+	    vmodel->data = 0;
 	}
 
 	/* Create new GL display list */
@@ -857,9 +857,9 @@ void *SARVisualModelNewList(sar_visual_model_struct *vmodel)
 	/* Set new GL display list as the data pointer on the visual
 	 * model structure
 	 */
-	vmodel->data = (void *)list;
+	vmodel->data = list;
 
-	return((void *)list);
+	return list;
 }
 
 /*

--- a/src/objutils.h
+++ b/src/objutils.h
@@ -74,7 +74,7 @@ extern sar_visual_model_struct *SARVisualModelNew(
 	sar_scene_struct *scene,
 	const char *filename, const char *name
 );
-extern void *SARVisualModelNewList(sar_visual_model_struct *vmodel);
+extern GLuint SARVisualModelNewList(sar_visual_model_struct *vmodel);
 extern int SARVisualModelGetRefCount(sar_visual_model_struct *vmodel);
 extern void SARVisualModelRef(sar_visual_model_struct *vmodel);
 extern void SARVisualModelUnref(

--- a/src/sardrawrunway.c
+++ b/src/sardrawrunway.c
@@ -85,9 +85,30 @@ void SARDrawRunway(
 		y_min, y_max,
 		yt_min, yt_max;
 	sar_position_struct cam_pos_runway;
+
 	if((length <= 0.0f) || (width <= 0.0f))
 	    return;
 
+	/* We will be skipping the drawing of some elements when rendering
+	   with GL_SELECT as it triggers ghosting of these elements (they are
+	   drawn and not removed anymore on subsequent frames). This is only
+	   done for ground contact check and these elements (thresholds,
+	   midway markers, touchdown markers, north-south text...) are not
+	   relevant objects. Under GL_SELECT an error is thrown sometimes on
+	   my intel hardware:
+
+	   "HW GL_SELECT does not support draw mode GL_LINES_ADJACENCY"
+
+	   GL_LINES_ADJACENCY must be internally use by the OpenGL
+	   implementation but ghosting also happens without it
+	   sometimes.. This appears to affect only runway elements. I am not
+	   sure why it doesn't affect Helipad or anything else
+	   apparently... *shrug*. This can well be a manifestation of a Mesa
+	   OpenGL bug with intel, as I have not found any other cause.
+	*/
+	GLint render_mode;
+	glGetIntegerv(GL_RENDER_MODE, &render_mode);
+	render_mode = GL_RENDER;
 
 	/* Get runway background texture */
 	if(SARIsTextureAllocated(scene, tex_num))
@@ -190,7 +211,7 @@ void SARDrawRunway(
 
 	    /* Draw north displaced threshold? */
 	    vmodel = runway->north_displaced_threshold_vmodel;
-	    if(vmodel != NULL)
+	    if(vmodel != NULL && render_mode != GL_SELECT)
 	    {
 		glPushMatrix();
 		{
@@ -207,7 +228,7 @@ void SARDrawRunway(
 	    }
 	    /* Draw south displaced threshold? */
 	    vmodel = runway->south_displaced_threshold_vmodel;
-	    if(vmodel != NULL)
+	    if(vmodel != NULL && render_mode != GL_SELECT)
 	    {
 		glPushMatrix();
 		{
@@ -272,7 +293,7 @@ void SARDrawRunway(
 
 	    /* Draw touchdown markers */
 	    vmodel = runway->td_marker_vmodel;
-	    if(vmodel != NULL)
+	    if(vmodel != NULL && render_mode != GL_SELECT)
 	    {
 		glPushMatrix();
 		{
@@ -299,7 +320,7 @@ void SARDrawRunway(
 
 	    /* Draw midway markers */
 	    vmodel = runway->midway_marker_vmodel;
-	    if(vmodel != NULL)
+	    if(vmodel != NULL && render_mode != GL_SELECT)
 	    {
 		glPushMatrix();
 		{
@@ -326,7 +347,7 @@ void SARDrawRunway(
 
 	    /* Draw threshold */
 	    vmodel = runway->threshold_vmodel;
-	    if(vmodel != NULL)
+	    if(vmodel != NULL && render_mode != GL_SELECT)
 	    {
 		glPushMatrix();
 		{
@@ -406,7 +427,8 @@ void SARDrawRunway(
 	    /* Draw north label? */
 	    vmodel = runway->north_label_vmodel;
 	    if((vmodel != NULL) &&
-	       (runway->north_label_width > 0.0f)
+	       (runway->north_label_width > 0.0f) &&
+	       render_mode != GL_SELECT
 	    )
 	    {
 		float label_width = runway->north_label_width;
@@ -427,7 +449,8 @@ void SARDrawRunway(
 	    /* Draw south label? */
 	    vmodel = runway->south_label_vmodel;
 	    if((vmodel != NULL) &&
-	       (runway->south_label_width > 0.0f)
+	       (runway->south_label_width > 0.0f) &&
+	       render_mode != GL_SELECT
 	    )
 	    {
 		float label_width = runway->south_label_width;

--- a/src/v3dgl.c
+++ b/src/v3dgl.c
@@ -1430,7 +1430,7 @@ static void V3DGLProcessModelStandard(
 			&widthp, &heightp,
 			&x_spacing, &y_spacing,
 			NULL,		/* No allocated z points. */
-			NULL,		/* GL list not important. */
+			0,		/* GL list not important. */
 			&hfopt
 		    );
 		    glPopMatrix();

--- a/src/v3dhf.c
+++ b/src/v3dhf.c
@@ -54,7 +54,7 @@ int V3DHFLoadFromFile(
 	double **data_rtn,	/* Dynamically allocated z points, each of
 				 * type double (can be NULL).
 				 */
-	void *gl_list,          /* GL list (can be NULL). */
+	GLuint gl_list,          /* GL list (can be NULL). */
 	v3d_hf_options_struct *hfopt
 );
 
@@ -157,7 +157,7 @@ int V3DHFLoadFromFile(
 	double **data_rtn,	/* Dynamically allocated z points, each of
 				 * type double (can be NULL).
 				 */
-	void *gl_list,          /* GL list (can be NULL). */
+	GLuint gl_list,          /* GL list (can be NULL). */
 	v3d_hf_options_struct *hfopt
 )
 {
@@ -344,7 +344,7 @@ int V3DHFLoadFromFile(
 	/* Begin issuing gl draw commands to draw the heightfield if
 	 * a GL list is given (which implies a GL list is being recorded.
 	 */
-	if((total_z_points > 0) && (gl_list != NULL))
+	if((total_z_points > 0) && (gl_list > 0))
 	{
 	    int cx, cy;         /* Current position in HF pixels (which is
 				 * also grid edge).

--- a/src/v3dhf.h
+++ b/src/v3dhf.h
@@ -22,6 +22,7 @@
 #define V3DHF_H
 
 #include <sys/types.h>
+#include <GL/gl.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,7 +76,7 @@ extern int V3DHFLoadFromFile(
 	double **data_rtn,      /* Dynamically allocated z points, each of
 				 * type double (can be NULL).
 				 */
-	void *gl_list,		/* GL list (can be NULL). */
+	GLuint gl_list,		/* GL list (can be NULL). */
 	v3d_hf_options_struct *hfopt
 );
 


### PR DESCRIPTION
See added comments in sardrawrunway.c.

Basically there is an opengl error message on my intel hardware worst of all some runway elements are ghosting all over the screen as soon as we run a ground contact check (which switches gl rendering mode to GL_SELECT for a frame).

This workaround disables rendering those elements during GL_SELECT. It seems to work mostly fine. I'm unsure that the issue is in the game but who knows.