### PR TITLE
Correct left rotor translation which was wrong only for object viewer.

### DIFF
--- a/data/aircrafts/v22.3d
+++ b/data/aircrafts/v22.3d
@@ -3722,8 +3722,9 @@ rotor_new 3       -7.0 0.3 0.6  0.0 0.0 180.0  5.7  1          0        1     1 
 #                r   g   b   a
 rotor_blur_color 0.1 0.1 0.1 0.75
 begin_model rotor
-#$model_flags 
-translate -7.000000 0.300000 0.600000
+#$model_flags
+# Note that Z must be set to 5.2 and not to 0.6 as it should be usually (5.2 = -blades_offset * 2 + 0.6).
+translate -7.000000 0.300000 5.200000
 color 0.050000 0.050000 0.050000 1.000000 1.000000 1.000000 1.000000 0.200000 0.000000
 # Blades
 begin_quads


### PR DESCRIPTION
I recently saw that V-22 left rotor position was **wrong in model viewer** (Free flight -> Aircraft -> Details...).
After some tests and look at sar2 code, I understood that moving parts as rotor, gears, ailerons, doors, and so on..., are not drawn in model viewer as in game.
In game, parts are drawn using rotor_new, landing_gear_new, aileron_left_new, rescue_door_new, and so on... parameters, but in model viewer, they are only drawn with translate and rotate parameters. It is why x, y, z and h, p, b rotor_new values are always '_copied and pasted_' to translate and rotate values (example: hh60.3d file):
`...`
`# Tail rotor`
`#         blades   x   y   z      h   p   b    r    prop_wash? flw_con? blur?`
`rotor_new 2       `**0.3 -9.1 0.6**`   `**0.0 0.0 80.0**`  1.5        0        0       1`
`#                r    g    b    a`
`rotor_blur_color 0.15 0.15 0.15 0.75`
`begin_model rotor`
`#$model_flags `
`translate `**0.300000 -9.100000 0.600000**
`rotate `**0.000000 0.000000 80.000000**
`# Struts to blades`
`...`
V-22 left rotor is an exception, it don't work in model viewer if translate 'z' value is copied from rotor_new 'z' value: value must be modified. 

I don't know if it is possible that copying 'z' value works for V-22 left rotor, but if yes, it would certainly need to modify some primitives in addition to rotor_new values.