### PR TITLE
Do not reduce number of humans that still need rescue in SARMissionHo…

### DIFF
--- a/src/mission.c
+++ b/src/mission.c
@@ -804,10 +804,16 @@ void SARMissionHoistInNotify(
 	   * instant all humans have been picked up.
 	   */
 	  case SAR_MISSION_OBJECTIVE_PICK_UP:
-	    /* Reduce number of humans that still need rescue, note that
+	    /* Original comment:
+	     * Reduce number of humans that still need rescue, note that
 	     * we do not care which object hoisted in these humans.
+	     *
+	     * New comment:
+	     * Do not reduce number of humans that still need rescue
+	     * because that has be done earlier by
+	     * SARMissionPassengersEnterNotify().
 	     */
-	    objective->humans_need_rescue -= hoisted_in;
+	    /* objective->humans_need_rescue -= hoisted_in; */
 
 	    /* All humans picked up? */
 	    if(objective->humans_need_rescue <= 0)


### PR DESCRIPTION
…istInNotify().

Finally, I understood where the issue was. Here is a log of what happen when a human is hoisted:

___src/simutils.c: Entering SARSimDoHoistIn()
______src/simutils.c: Entering SARSimBoardObject()
_________src/mission.c: Entering SARMissionPassengersEnterNotify()
___________ _**objective->humans_need_rescue is reduced here**_
_________src/mission.c: Leaving SARMissionPassengersEnterNotify()
______src/simutils.c: Leaving SARSimBoardObject()
______src/mission.c: Entering SARMissionHoistInNotify()
________ _**objective->humans_need_rescue is reduced here**_
______src/mission.c: Leaving SARMissionHoistInNotify()
___src/simutils.c: Leaving SARSimDoHoistIn()

Removing the second decrementation solves the issue #20 . If the first decrementation (the one in SARMissionPassengersEnterNotify()) is removed instead of the second one, it causes other issues.
