### PR TITLE
Add a -do-not-transform option

### DIFF
--- a/tools/v3dconverter/readme.txt
+++ b/tools/v3dconverter/readme.txt
@@ -1,24 +1,24 @@
- 
+
    +--------------------------+
    | V3dconverter quick start |
    +--------------------------+
 
 * FOREWORD:
     This tools is under development. Only *.obj to *.3d conversion is fully operational at now. Convert *.3d terrain to *.obj in order to edit an height field seems to gives good results too. Convert other *.3d objects to *.obj or convert *.ac to *.3d will only work if you're lucky, therefore for now please report bugs only for *.obj to *.3d conversion. I do 99% of my testing by exporting files from Blender in *.obj format, then converting them to *.3d format with v3dconverter.
-    
+
 * DESCRIPTION:
-    V3dconverter is a file converter for Sar2 developers. Its purpose is to convert *.3d (Vertex 3d) model files from/to *.obj (WaveFront) or *.ac (AC3D) files.
+    V3dconverter is a file converter for Sar2 developers. Its purpose is to convert *.3d (Vertex 3d) model or *.hf (terrain) files from/to *.obj (WaveFront) or *.ac (AC3D) files.
 
 * HOW TO COMPILE:
     cd /path/to/v3dconverter
-    gcc -lm -Wall -o v3dconverter v3dconverter.c
+    gcc -lm -Wall -o v3dconverter ./src/v3dconverter.c
 
 * HOW TO USE:
     ./v3dconverter -h
 
 * IMPORTANT NOTES:
     - Don't stole 3D models. Create a model can take a lot of hours/days/months of hard work. Ensure that original model is free before add it in Sar2. If you're not sure of that, please try to contact model author and kindly ask him for permission to reuse it in Sar2.
-    - Even if v3dconverter can convert *.ac to *.3d and even if FlightGear models are generally free, it is not a very good idea to become a "FlightGear models serial converter". FlightGear models -especially flying ones- can be very detailed, generally too much detailed for Sar2. A better way is to open and simplificate them as much as possible (I use mainly Blender and / or sometimes Meshlab to do that) BEFORE convert them to *.3d format.
+    - Even if v3dconverter can convert *.ac to *.3d and even if FlightGear models are generally free, it is not a very good idea to become a "FlightGear models serial converter". FlightGear models -especially flying ones- can be very detailed, generally too much detailed for Sar2. A better way is to open and simplify them as much as possible (I use mainly Blender and / or sometimes Meshlab to do that) BEFORE convert them to *.3d format.
     - V3dconverter will only do for you the longest and less interesting job, i.e. convert 3D primitives. To get clean Sar2 models, you will certainly have to manually add/remove/modify some stuffs in your *.3d file, and you always will have to convert texture files.
 
 * CONVERSION TIPS:
@@ -34,12 +34,13 @@
     - If your *.3d model seems to have all faces inverted (for example, if when you look at your model from front of it, you see its back texture), you can try "-if" option to invert faces visibility (flip winding).
     - If you have removed all pure black colors and it already seems that some parts of you model are missing, maybe that missing faces have to be flipped. This can be checked with Blender by showing face orientation. Select bad meshes then use Mesh -> Normals -> Flip to flip them.
     - Especially if you wants to create new aircrafts, don't hesitate to save your *.obj or *.ac file into small parts, then convert these parts to *.3d, then manually reassemble your multiple *.3d files in the final one. If not, it can be very difficult to define aircraft moving parts (begin_model ... / end_model ...) as rotors, gears, doors, flaps, an so on...
+    - If you want to understand "how aircraft moving parts work", it can be usefull to convert an existing *.3d aircraft file to *.obj using the v3dconverter '-do-not-transform' option: moving parts will be drawn "as sar2 see them when it reads the *.3d file".
     - To check your model rendering in Sar2 without add it in a scenery, copy or link your *.3d file in data/aircrafts/ directory, then start Sar2 (aircrafts list is loaded at startup), go to Free Flight, click on Aircraft button, select your model in list, then click on Details button. If your model is not a flying one, don't forget to remove your file / link from aircrafts directory once checked.
     - Sometimes, v3dconverter prints a lot of (too much ?) warnings. These warnings can be redirected in a text file as this: v3dconverter -i "my input file.obj" -o my_output_file.3d 2> warnings.txt .
     - If in Blender, your imported *.obj model has no texture and appears pink, it's because Blender can't find the path of textures. This can be fixed by creating a link to the textures folder (for example: "cd my_working_directory && ln -s /usr/share/sar2/textures/"), or by copying the whole textures folder in your working directory, or by editing your model *.mtl file (look for "map_Kd ..........." in *.mtl file).
     - A Sar2 height field (*.hf) is a rebadged *.tga (Truevision Targa), 8 bits grey color, top left origin, without RLE (Run Length Encoding) compression image.
     - Keep in mind that *.3d terrain to *.obj conversion -> manual terrain editing -> *.obj to *.hf conversion, is only available for altitude ("Z axis") modification. X and/or Y edition will cause *.obj to *.hf conversion to stop.
-    - Keep in mind that v3dconverter uses *.3d file data to convert terrain to *.obj, thus it will place your *.obj terrain "as in Sar2". It is very usefull if your terrain is made from multiple tiles, because once each terrain tile converted to *.obj, you can import all of them in Blender and they will automatically be put at the right place, but, if you import only one tile and if translation in *.3d file is not null, terrain can be far away from view center (0,0,0). If you want that it be centered in Blender view, DO NOT move it from Blender, add a -tr (translate) option to your conversion command line. If you move it from Blender, *.obj to *.hf conversion will fail.
-    - If you want to edit a terrain file in Blender, it's a good idea to add a -sc 1/100 (i.e. scale 1/100) or -sc 1/1000 option to your v3dconverter command line. If not and if -like me- you are not a Blender professional, it will be difficult to see your terrain because it will be too big for camera clipping and focal length. Don't worry about scale value: it will be stored during *.3d to *.obj conversion process, then automatically canceled during *.obj to *.hf conversion. 
+    - Keep in mind that v3dconverter uses *.3d file data to convert terrain to *.obj, thus it will place your *.obj terrain "as in Sar2" (unless you specified the '-do-not-transform' option). It is very usefull if your terrain is made from multiple tiles, because once each terrain tile converted to *.obj, you can import all of them in Blender and they will automatically be put at the right place, but, if you import only one tile and if translation in *.3d file is not null, terrain can be far away from view center (0,0,0). If you want that it be centered in Blender view, DO NOT move it from Blender, add a -tr (translate) option to your conversion command line, or use the '-do-not-transform' option. If you move it from Blender, *.obj to *.hf conversion will fail.
+    - If you want to edit a terrain file in Blender, it's a good idea to add a -sc 1/100 (i.e. scale 1/100) or -sc 1/1000 option to your v3dconverter command line. If not and if -like me- you are not a Blender professional, it will be difficult to see your terrain because it will be too big for camera clipping and focal length. Don't worry about scale value: it will be stored during *.3d to *.obj conversion process, then automatically canceled during *.obj to *.hf conversion.
     - Warning: in *.obj terrain files, material has a strange name: this name don't be modified because it will be used as a file name to retrieve important data during *.obj to *.hf conversion process. If you're curious, have a look in $HOME/.local/share/v3dconverter.
     - You can easily compare two *.hf files with ImageMagick like this: "magick compare image_1.hf.tga image_2.hf.tga -compose src difference.png".

--- a/tools/v3dconverter/src/utils.c
+++ b/tools/v3dconverter/src/utils.c
@@ -53,24 +53,24 @@ long file_size(const char *filename)
 
 
 /* Parse a full file and fill path, baseName, and extention strings.
- * 
+ *
  * Examples:
- * 
+ *
  * fullFileName = "./a/such/full/name.txt" returns:
  * path = "./a/such/full/"
  * baseName = "name"
  * extension = ".txt"
- * 
+ *
  * fullFileName = "a/such/path/" returns:
  * path = "a/such/path/"
  * baseName = ""
  * extension = ""
- * 
+ *
  */
 void scanFileName( const char *fullFileName, char **path, char **baseName, char **extension )
 {
     int cnt0 = 0, fullFileNameLength = 0, lastSlashPos = 0, fullPathLength = 0, lastDotPos = 0;
-    
+
     if ( *path != NULL )
     {
 	free( *path );
@@ -86,7 +86,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	free( *extension );
 	*extension = NULL;
     }
-    
+
     /* full file name length */
     fullFileNameLength = strlen( fullFileName );
 
@@ -96,17 +96,17 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	if ( ( *( fullFileName + lastSlashPos ) == '/' ) || ( *( fullFileName + lastSlashPos ) == '\\' ) )
 	    break;
     }
-    
+
     /*  path length */
     fullPathLength = lastSlashPos + 1;
-    
+
     /*  last dot position */
     for ( lastDotPos = fullFileNameLength; lastDotPos > fullPathLength; lastDotPos-- )
     {
 	if ( *( fullFileName + lastDotPos ) == '.' )
 	    break;
     }
-    
+
     /* extract base name, path, and extension */
     if ( lastSlashPos < 0 && lastDotPos == 0) // full file name has NO path and NO extension
     {
@@ -120,7 +120,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	for ( cnt0 = 0; cnt0 < fullFileNameLength; cnt0++ )
 	    *( *baseName + cnt0 ) = *( fullFileName + cnt0 );
 	*( *baseName + cnt0 ) = '\0'; // close string
-	
+
 	/* no path */
 	*path = malloc ( sizeof (char) );
 	if ( *path == NULL )
@@ -129,7 +129,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	    exit (EXIT_FAILURE);
 	}
 	**path = '\0'; // close string
-	
+
 	/* no extension */
 	*extension = malloc ( sizeof (char) );
 	if ( *extension == NULL )
@@ -138,7 +138,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	    exit (EXIT_FAILURE);
 	}
 	**extension = '\0'; // close string
-	
+
     }
     else if ( lastDotPos == fullPathLength ) // full file name has NO extension
     {
@@ -149,13 +149,13 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	    fprintf(stderr, "Memory allocation error.\n");
 	    exit (EXIT_FAILURE);
 	}
-	
+
 	for ( cnt0 = fullPathLength; cnt0 < fullFileNameLength; cnt0++ )
 	{
 	    *( *baseName - fullPathLength + cnt0 ) = *( fullFileName + cnt0 );
 	}
 	*( *baseName - fullPathLength + cnt0 ) = '\0'; // close string
-	
+
 	/* extract path */
 	*path = malloc ( ( lastSlashPos + 2 ) * sizeof (char) );
 	if ( *path == NULL )
@@ -168,7 +168,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	    *( *path + cnt0 ) = *( fullFileName + cnt0 );
 	}
 	*( *path + cnt0 ) = '\0'; // close string
-	
+
 	/* no extension */
 	*extension = malloc ( sizeof (char) );
 	if ( *extension == NULL )
@@ -190,7 +190,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	for ( cnt0 = fullPathLength; cnt0 < lastDotPos; cnt0++ )
 	    *( *baseName - fullPathLength + cnt0 ) = *( fullFileName + cnt0 );
 	*( *baseName - fullPathLength + cnt0 ) = '\0'; // close string
-	
+
 	/* extract path */
 	*path = malloc ( ( lastSlashPos + 2 ) * sizeof (char) );
 	if ( *path == NULL )
@@ -203,7 +203,7 @@ void scanFileName( const char *fullFileName, char **path, char **baseName, char 
 	    *( *path + cnt0 ) = *( fullFileName + cnt0 );
 	}
 	*( *path + cnt0 ) = '\0'; // close string
-	
+
 	/* extract extension */
 	*extension = malloc ( ( fullFileNameLength - lastDotPos + 1 ) * sizeof (char) );
 	if ( *extension == NULL )
@@ -224,7 +224,7 @@ int calculateSurfaceNormal ( Vcoord *v, int verticies, Vnormal *vn )
 {
     // Newell's method, from: https://www.khronos.org/opengl/wiki/Calculating_a_Surface_Normal pseudo-code
     // Returns EXIT_FAILURE (0) in case of div by zero error
-    
+
     Vcoord vCurrent, vNext;
     int cnt1 = 0;
 
@@ -232,27 +232,27 @@ int calculateSurfaceNormal ( Vcoord *v, int verticies, Vnormal *vn )
     vn->i = 0;
     vn->j = 0;
     vn->k = 0;
-    
+
     for ( int cnt0 = 0; cnt0 < verticies; cnt0++ )
     {
 	vCurrent.x = v[ cnt0 ].x;
 	vCurrent.y = v[ cnt0 ].y;
 	vCurrent.z = v[ cnt0 ].z;
-	
+
 	if ( ( cnt0 + 1 ) >= verticies )
 	    cnt1 = 0;
 	else
 	    cnt1 = cnt0 + 1;
-	
+
 	vNext.x = v[ cnt1 ].x;
 	vNext.y = v[ cnt1 ].y;
 	vNext.z = v[ cnt1 ].z;
-	
+
 	vn->i += ( vCurrent.y + vNext.y ) * ( vCurrent.z - vNext.z );
 	vn->j += ( vCurrent.z + vNext.z ) * ( vCurrent.x - vNext.x );
 	vn->k += ( vCurrent.x + vNext.x ) * ( vCurrent.y - vNext.y );
     }
-    
+
     // normalize
     double vecLength = sqrt( vn->i * vn->i + vn->j * vn->j + vn->k * vn->k );
     if ( vecLength == 0 )
@@ -277,15 +277,15 @@ char *timeStamp() // returns a YYYYMMDDHHMMSS timestamp
   time(&now);
   // Convert to local time
   struct tm *local = localtime(&now);
-  h = local->tm_hour;        
-  min = local->tm_min;       
-  s = local->tm_sec;       
-  day = local->tm_mday;          
-  month = local->tm_mon + 1;     
-  year = local->tm_year + 1900;  
+  h = local->tm_hour;
+  min = local->tm_min;
+  s = local->tm_sec;
+  day = local->tm_mday;
+  month = local->tm_mon + 1;
+  year = local->tm_year + 1900;
 
   timeStampString = strdup("YYYYMMDDHHMMSS");
-  sprintf(timeStampString, "%02d%02d%d%02d%02d%02d", year, month, day, h, min, s);
+  sprintf(timeStampString, "%04d%02d%02d%02d%02d%02d", year, month, day, h, min, s);
 
   return(timeStampString);
 }
@@ -294,9 +294,9 @@ char *timeStamp() // returns a YYYYMMDDHHMMSS timestamp
 bool isTex ( const char *fullFileName ) // returns 'true' if file baseName contains '.tex'
 {
     char *path = NULL, *baseName = NULL, *extension = NULL;
-    
+
     scanFileName( fullFileName, &path, &baseName, &extension );
-    
+
     if ( strstr( baseName, ".tex" ) )
 	return true;
     else
@@ -307,9 +307,9 @@ bool isTex ( const char *fullFileName ) // returns 'true' if file baseName conta
 bool isHf ( const char *fullFileName ) // returns 'true' if file baseName contains '.hf'
 {
     char *path = NULL, *baseName = NULL, *extension = NULL;
-    
+
     scanFileName( fullFileName, &path, &baseName, &extension );
-    
+
     if ( strstr( baseName, ".hf" ) )
 	return true;
     else

--- a/tools/v3dconverter/src/v3dconverter.c
+++ b/tools/v3dconverter/src/v3dconverter.c
@@ -43,7 +43,7 @@ int main( int argc, char *argv[] )
     char *scaleString;
     char lineBuffer[MAX_LENGTH + 1], objTag[MAX_LENGTH + 1];
     FILE *fp;
-    
+
     struct UserModifier userModifier;
     userModifier.rx = 0;
     userModifier.ry = 0;
@@ -53,7 +53,8 @@ int main( int argc, char *argv[] )
     userModifier.tz = 0;
     userModifier.scale = 1.0;
     userModifier.invertFaces = false;
-    
+    userModifier.doNotTransformModels = false;
+
     if ( argc == 1 )
     {
 	fprintf( stdout, "Try \"%s -h\" for help.\n", argv[0] );
@@ -67,6 +68,8 @@ int main( int argc, char *argv[] )
         fprintf( stdout, "   OPTIONS:\n");
         fprintf( stdout, "     -if\n");
         fprintf( stdout, "        Invert faces visibility (flip winding).\n");
+	fprintf( stdout, "     -do-not-transform\n");
+        fprintf( stdout, "        Do not apply any translation and/or rotation when converting a *.3d model or *.hf terrain to an other file format: usefull  to center a terrain tile in Blender or to understand how to create rotors, gears, ailerons, and other moving parts.\n");
 	fprintf( stdout, "     -ro x y z\n");
         fprintf( stdout, "        Rotate object of x, y, and z degrees around respectives axes.\n" );
 	fprintf( stdout, "     -sc scale\n");
@@ -95,10 +98,10 @@ int main( int argc, char *argv[] )
 	fprintf( stdout, "        .   : Not planned.\n" );
 	fprintf( stdout, "     For other formats, try assimp: https://www.assimp.org/\n" );
         fprintf( stdout, "     \n" );
-	
+
         return 0;
     }
-    
+
     /* Read command line arguments */
     for ( unsigned short counter = 1; counter < argc; counter++ )
     {
@@ -126,6 +129,10 @@ int main( int argc, char *argv[] )
 	{
             userModifier.invertFaces = true;
         }
+	else if ( !strcmp(argv[counter], "-do-not-transform") ) // do not apply rotate / translate during *.3d to *.obj conversion
+	{
+	    userModifier.doNotTransformModels = true;
+        }
         else if ( !strcmp(argv[counter], "-sc") ) // scale model
 	{
             if ( counter < argc )
@@ -135,7 +142,7 @@ int main( int argc, char *argv[] )
 		fprintf( stderr, "Error while reading scale.\n" );
 		return 0;
 	    }
-	    
+
             if ( memchr( scaleString, '/', strlen(scaleString) ) != NULL )
 	    {
                 long dividend = 1, divider = 1;
@@ -144,7 +151,7 @@ int main( int argc, char *argv[] )
             }
             else
                 sscanf( scaleString, "%lf", &userModifier.scale );
-	    
+
             if ( userModifier.scale < 0 )
 	    {
 		fprintf( stdout, "\033[7mNegative scale will produce strange results. You've been warned!\033[0m\n" );
@@ -206,7 +213,7 @@ int main( int argc, char *argv[] )
 	    return 0;
 	}
     }
-    
+
     /* Convert */
     if ( !strcmp( extOf( source ), ".3d") && !strcmp( extOf( destination ), ".obj" ) )
     {
@@ -239,7 +246,7 @@ int main( int argc, char *argv[] )
 		;
 	}
 	fclose( fp );
-	
+
 	/* Select the right function, depending of *.3d file type ("object" or "terrain") */
 	if ( !hasHeightfield )
 	{ // it is *.3d object file
@@ -301,6 +308,11 @@ int main( int argc, char *argv[] )
 		userModifier.tx = 0;
 		userModifier.ty = 0;
 		userModifier.tz = 0;
+	}
+	if ( userModifier.invertFaces == true )
+	{
+	    fprintf( stdout, "[ INFO ] -do-not-transform (do not apply any translation and/or rotation) option currently not available in *.ac to *.3d conversion.\n" );
+	    userModifier.doNotTransformModels = false;
 	}
         ac3dToV3d( source, destination, &userModifier );
     }

--- a/tools/v3dconverter/src/v3dconverter.h
+++ b/tools/v3dconverter/src/v3dconverter.h
@@ -15,9 +15,10 @@
 ***********************************************************************/
 
 
-#define VERSION "0.3.2"
+#define VERSION "0.3.3"
 
 #include <linux/limits.h> // for PATH_MAX
+#include <stdbool.h>
 #define MAXPATHLENGTH PATH_MAX
 
 #define MAX_LENGTH 2048
@@ -25,6 +26,12 @@
 
 #define OBJ_OBJECT_NAME_TERRAIN "Terrain"
 #define OBJ_OBJECT_NAME_V3DCONVERTER_DATA "v3dConverter_data_DO_NOT_REMOVE"
+
+// TGA image descriptor, bits 5 & 4
+#define TGA_BOTTOM_LEFT_MASK  0b00000000
+#define TGA_BOTTOM_RIGHT_MASK 0b00010000
+#define TGA_TOP_LEFT_MASK     0b00100000
+#define TGA_TOP_RIGHT_MASK    0b00110000
 
 typedef struct UserModifier UserModifier;
 struct UserModifier {
@@ -35,7 +42,8 @@ struct UserModifier {
     double ty;
     double tz;
     double scale;
-    unsigned short invertFaces;
+    bool invertFaces;
+    bool doNotTransformModels;
 };
 
 // vertex geometric coords

--- a/tools/v3dconverter/src/v3dtoobj.c
+++ b/tools/v3dconverter/src/v3dtoobj.c
@@ -57,7 +57,7 @@ long readV3dVerticies ( FILE *fpIn, const char * endBoundString, FILE *fpOut, ch
             lineNr++; // input file line counter
             break;
         }
-        
+
         if ( !strcmp(strtoupper( result, buffer), "") ) { // it's an empty line
             break;
         }
@@ -78,13 +78,13 @@ long readV3dVerticies ( FILE *fpIn, const char * endBoundString, FILE *fpOut, ch
 		    isAVertexNormal = 1; // new "NORMAL" statement found, first "NORMAL" statement was a vertex normal
 	    }
 	    fsetpos(fpIn, &position); // return to original in-file position
-	    
+
 	    if ( isAVertexNormal == 1 )
 	    {
 		vn++;
 		sscanf( lineBuffer, "%*s %lf %lf %lf", &nx, &ny, &nz );
 		fprintf( fpOut, "vn ");
-		
+
 		// apply v3d rotation and position modifiers
 		if ( modifier.rh ) RotateZ ( &nx, &ny, &nz, &pw, modifier.rh );
 		if ( modifier.rp ) RotateX ( &nx, &ny, &nz, &pw, modifier.rp );
@@ -92,7 +92,7 @@ long readV3dVerticies ( FILE *fpIn, const char * endBoundString, FILE *fpOut, ch
 		nx += modifier.tx;
 		ny += modifier.ty;
 		nz += modifier.tz;
-	    
+
 		/* TODO apply user modifiers. Apply order is: X rotation, then Y rotation, then Z rotation, then scale, then translations. */
 		/*
 		if ( userModifier->rx != 0.0 )
@@ -108,11 +108,11 @@ long readV3dVerticies ( FILE *fpIn, const char * endBoundString, FILE *fpOut, ch
 		    RotateZ ( &nx, &ny, &nz, &pw, userModifier->rz );
 		}
 		*/
-	    
+
 		/* re-orient normal them because v3d coords system is different from obj coords system */
 		RotateZ ( &nx, &ny, &nz, &pw, -90 ); // rotate normal arround Z axis. Angle given in degrees.
 		RotateX ( &nx, &ny, &nz, &pw, 90 ); // rotate normal arround X axis. Angle given in degrees.
-	    
+
 		// write vertex normal
 		fprintf( fpOut, "%lf %lf %lf\n", nx, ny, nz );
 	    }
@@ -121,7 +121,7 @@ long readV3dVerticies ( FILE *fpIn, const char * endBoundString, FILE *fpOut, ch
             vt++;
             fprintf( fpOut, "vt ");
 	    sscanf( lineBuffer, "%*s %lf %lf", &tu, &tv ); // u, v
-	    
+
             // write texture coords
             fprintf( fpOut, "%lf %lf\n", tu, tv ); // u, v
         }
@@ -131,11 +131,11 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
             vt++;
             fprintf( fpOut, "vt ");
             sscanf( lineBuffer, "%*s %lf %lf %lf", &x, &y, &z ); // u, v, w
-        
+
             //if ( modifier.rh ) RotateZ ( &x, &y, &z, &pw, modifier.rh );
             //if ( modifier.rp ) RotateX ( &x, &y, &z, &pw, modifier.rp );
             //if ( modifier.rb ) RotateY ( &x, &y, &z, &pw, modifier.rb );
-        
+
             //x += modifier.tx;
             //y += modifier.ty;
             //z += modifier.tz;
@@ -146,7 +146,7 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
             v++;
             fprintf( fpOut, "v ");
             sscanf( lineBuffer, "%lf %lf %lf", &vx, &vy, &vz );
-            
+
             if ( textureOrient[0] != '\0' ) { // if there is a running "texture_orient_" command, then create a texture vertex
                 vt++;
                 sscanf( textureOrient, "%*s %lf %lf %lf %lf", &ta, &tb, &tda, &tdb ); // "texture_orient_" command parameters
@@ -170,9 +170,9 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
                     if ( vz > tb ) tv = ( vz - tb ) / tdb;
                     else tv = ( tb - vz ) / tdb;
                 }
-                
+
             }
-	    
+
             // apply v3d rotation and position modifiers
             if ( modifier.rh ) RotateZ ( &vx, &vy, &vz, &pw, modifier.rh );
             if ( modifier.rp ) RotateX ( &vx, &vy, &vz, &pw, modifier.rp );
@@ -180,7 +180,7 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
             vx += modifier.tx;
             vy += modifier.ty;
             vz += modifier.tz;
-	    
+
 	    /* TODO apply user modifiers. Apply order is: X rotation, then Y rotation, then Z rotation, then scale, then translations. */
 	    /*
 	    if ( userModifier->rx != 0.0 )
@@ -196,11 +196,11 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
 		RotateZ ( &vx, &vy, &vz, &pw, userModifier->rz );
 	    }
 	    */
-	    
+
             /* re-orient vertex because v3d coords system is different from obj coords system */
 	    RotateZ ( &vx, &vy, &vz, &pw, -90 ); // rotate vertex arround Z axis. Angle given in degrees.
 	    RotateX ( &vx, &vy, &vz, &pw, 90 ); // rotate vertex arround X axis. Angle given in degrees.
-	    
+
             fprintf( fpOut, "%lf %lf %lf\n", vx, vy, vz ); // write geometric vertex
             if ( textureOrient[0] != '\0' ) { // write texture vertex
                 fprintf( fpOut, "vt %lf %lf\n", tu, tv );
@@ -341,7 +341,7 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
             fprintf(fpOut, " %d/%d/%d", v3, v3, v3 );
         }
         fprintf(fpOut, "\n");
-            
+
         // next triangles
         for ( int cnt0 = primitives - 1; cnt0 > 0; cnt0 = cnt0 - 2 ) {
             v1 = v1 + 1;
@@ -368,7 +368,7 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
                 fprintf(fpOut, " %d/%d/%d", v3, v3, v3 );
             }
             fprintf(fpOut, "\n");
-            
+
             v1 = v1 + 1;
             if ( v1 < 0 ) {
                 v2 = v2 + 2;
@@ -485,7 +485,7 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
             fprintf(fpOut, " %d/%d/%d", -primitives * 2 + 1, -primitives * 2 + 1, -primitives * 2 + 1 );
         }
         fprintf(fpOut, "\n");
-        
+
         // next quads
         for ( int cnt0 = primitives - 1; cnt0 > 0; cnt0-- ) {
             int offset = -cnt0 * 2;
@@ -539,10 +539,10 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
         primitives = 1; // for printf output
     }
     ////////////////////////////////////////////////////printf("%d %s with %d v, %d vt, %d vn\n", primitives, endBoundString, v, vt, vn);
-    
-    
-    
-    
+
+
+
+
     /*
     fprintf( fpOut, "****************\n");
     fseek(fpIn, startPosition, SEEK_SET);
@@ -552,7 +552,7 @@ printf("TEXTURE VERTEX FOUND at line #%ld\n", lineNr);
     }
     fprintf( fpOut, "****************\n");
     */
-    
+
     return primitives;
 }
 
@@ -564,43 +564,43 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
     char modelType[22 + 1]; // longest model type: 'aileron_elevator_right'
     long fileSize = 0;
     unsigned int points = 0, lines = 0, line_strip = 0, line_loop = 0, triangle = 0, triangle_strip = 0, triangle_fan = 0, quads = 0, quad_strip = 0, polygon = 0, color = 0, texture = 0, objectNr = 0;
-    
+
     modifier.tx = 0;
     modifier.ty = 0;
     modifier.tz = 0;
     modifier.rh = 0;
     modifier.rp = 0;
     modifier.rb = 0;
-    
+
     textureName[0] = '\0'; // no texture at startup
     textureOrient[0] = '\0'; // no texture at startup
-    
+
     fileSize = file_size(source);
     printf("*.3d file size: %ld bytes.\n", fileSize);
-    
+
     if ((fpIn = fopen(source, "r")) == NULL) {
         perror(source);
         return -1;
     }
-    
+
     // Generate output file name
     scanFileName( dest, &path, &baseName, &extension );
-    
+
     if ( path[0] == '\0' ) // if no path
 	sprintf( buffer, "%s.obj", baseName );
     else
 	sprintf( buffer, "%s/%s.obj", path, baseName );
-    
+
     if ((fpOut = fopen(buffer, "w")) == NULL) {
         perror(buffer);
         return -1;
     }
-    
+
     if ( path[0] == '\0' ) // if no path
 	sprintf( buffer, "%s.mtl", baseName );
     else
 	sprintf( buffer, "%s/%s.mtl", path, baseName );
-    
+
     if ((fpMtl = fopen(buffer, "w")) == NULL) {
         perror(buffer);
         return -1;
@@ -610,7 +610,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
     }
 
     /////////////////////////////fprintf(fpOut, "g %s\n", baseName); // create a group and give it 3d model name FIXME: can be an issue if model name contains one ore more spaces!
-    
+
     /*
     // count file lines, then create as many verticies as lines number (not efficient but easier way to do the job...)
     long counter = 0;
@@ -624,7 +624,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
     struct Vertex vertex[counter];
     rewind(fpIn);
     */
-    
+
     while ( fgets(lineBuffer, MAX_LENGTH, fpIn) ) {
 	strcpy( buffer, ""); // clear buffer
         sscanf( lineBuffer, "%s %s", buffer, parameter1 );
@@ -687,10 +687,10 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
             // create material in *.mtl file
             //char red[20], green[20], blue[20], transparency[20], ambient[20], diffuse[20], specular[20], shininess[20], emission[20];
             double red = 0, green = 0, blue = 0, transparency = 0, ambient = 1, diffuse = 1, specular = 1, shininess = 1, emission = 1;
-            
+
 	    // TODO FIXME check if material already exists before creating a new one !!! If not, a VERY big quantity of materials can be generated and Blender don't like it!!!
             fprintf(fpMtl, "newmtl color_%d\n", color);
-	    
+
             if ( sscanf( lineBuffer, " %*s %lf %lf %lf %lf %lf %lf %lf %lf %lf", &red, &green, &blue, &transparency, &ambient, &diffuse, &specular, &shininess, &emission ) ) {
 		/*
                 fprintf(fpMtl, "Ka %lf %lf %lf\n", red * ambient, green * ambient, blue * ambient);
@@ -699,11 +699,11 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
 		fprintf(fpMtl, "Ka 0.200000 0.200000 0.200000\n");
                 fprintf(fpMtl, "Ks 1.000000 1.000000 1.000000\n");
 		fprintf(fpMtl, "Kd %lf %lf %lf\n", red * diffuse, green * diffuse, blue * diffuse);
-                
+
                 // Ka r g b : The Ka statement specifies the ambient reflectivity using RGB values.
                 // Kd r g b : The Kd statement specifies the diffuse reflectivity using RGB values.
                 // Ks r g b : The Ks statement specifies the specular reflectivity using RGB values.
-                // Illumination    Properties that are turned on in the 
+                // Illumination    Properties that are turned on in the
                 // model           Property Editor
                 //  0		Color on and Ambient off
                 //  1		Color on and Ambient on
@@ -727,7 +727,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
                 fprintf(fpMtl, "Kd 0.5 0.5 0.5\n"); // grey
             }
             fprintf(fpMtl, "illum 1\n");
-            
+
             // specify material in *.obj file
             fprintf(fpOut, "usemtl color_%d\n", color);
             textureName[0] = '\0';
@@ -745,6 +745,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
             sscanf( lineBuffer, "%*s %s", modelType );
             // We can't use only the model type as object name because a *.3d file can contain more than one "begin_model" statement with the same model type (example: begin_model rotor)
             fprintf( fpOut, "o obj%d_%s\n", objectNr++, modelType );
+	    strtoupper( modelType, (const char *) modelType );
             fprintf(fpOut, "usemtl color_%d\n", color);
             textureName[0] = '\0';
             textureOrient[0] = '\0';
@@ -754,6 +755,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
             sscanf( lineBuffer, "%*s %s", modelType );
             // We can't use only the model type as object name because a *.3d file can contain more than one "begin_model" statement with the same model type (example: begin_model rotor)
             fprintf( fpOut, "o obj%d_%s\n", objectNr++, modelType );
+	    strtoupper( modelType, (const char *) modelType );
         }
         else if ( !strcmp(tagName, "END_MODEL") ) {
             modifier.tx = 0;
@@ -764,9 +766,11 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
             modifier.rb = 0;
             textureName[0] = '\0';
             textureOrient[0] = '\0';
+            strcpy(modelType, "");
         }
         else if ( !strcmp(tagName, "TRANSLATE") ) {
-            sscanf( lineBuffer, "%*s %lf %lf %lf", &modifier.tx, &modifier.ty, &modifier.tz );
+	    if ( userModifier->doNotTransformModels != true )
+		sscanf( lineBuffer, "%*s %lf %lf %lf", &modifier.tx, &modifier.ty, &modifier.tz );
         }
         else if ( !strcmp(tagName, "UNTRANSLATE") || !strcmp(tagName, "END_MODEL") ) {
             modifier.tx = 0;
@@ -774,7 +778,8 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
             modifier.tz = 0;
         }
         else if ( !strcmp(tagName, "ROTATE") ) {
-            sscanf( lineBuffer, "%*s %lf %lf %lf", &modifier.rh, &modifier.rp, &modifier.rb );
+	    if ( userModifier->doNotTransformModels != true )
+		sscanf( lineBuffer, "%*s %lf %lf %lf", &modifier.rh, &modifier.rp, &modifier.rb );
         }
         else if ( !strcmp(tagName, "UNROTATE") || !strcmp(tagName, "END_MODEL") ) {
             modifier.rh = 0;
@@ -786,13 +791,13 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
             sscanf( lineBuffer, "%*s %s %s %s", textureName, texturePath, priority );
             fprintf(fpMtl, "newmtl %s\n", textureName);
             fprintf(fpMtl, "Kd 1.000000 1.000000 1.000000\n");
-	    
+
 	    /* fast but dirty way to modify extension */
 	    int extensionPosition = strlen( texturePath ) - 3;
 	    texturePath[ extensionPosition++ ] = 't';
 	    texturePath[ extensionPosition++ ] = 'g';
 	    texturePath[ extensionPosition ] = 'a';
-	    
+
             fprintf(fpMtl, "map_Kd %s\n", texturePath);
             textureName[0] = '\0';
             textureOrient[0] = '\0';
@@ -801,7 +806,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
         else if ( !strcmp(tagName, "TEXTURE_SELECT") ) {
             sscanf( lineBuffer, "%*s %s", textureName );
             fprintf( fpOut, "usemtl %s\n", textureName );
-            
+
             textureOrient[0] = '\0';
         }
         else if ( !strcmp(tagName, "TEXTURE_ORIENT_XY") ||  !strcmp(tagName, "TEXTURE_ORIENT_XZ") || !strcmp(tagName, "TEXTURE_ORIENT_YZ")) {
@@ -820,15 +825,15 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
                 fprintf(fpOut, "\n");
             }
             //while ( (c = fgetc(fpIn)) != '\n') fprintf(fpOut, "%c", c);
-            
+
         }
-        
+
         lineNr++; // input file line counter
     }
     printf("%s contains:\n %d points, %d lines, %d line_strip, %d line_loop, %d triangle, %d triangle_strip, %d triangle_fan, %d quads, %d quad_strip, %d polygon, and %d color statements.\n", source, points, lines, line_strip, line_loop, triangle, triangle_strip, triangle_fan, quads, quad_strip, polygon, color);
-    
+
     printf("Files %s.obj and %s.mtl written to: %s directory.\n", baseName, baseName, path);
-    
+
     if ( path != NULL )
     {
 	free( path );
@@ -844,7 +849,7 @@ int v3dToObj( const char *source, const char *dest, UserModifier *userModifier )
 	free( extension );
 	extension = NULL;
     }
-    
+
     fclose(fpMtl);
     fclose(fpOut);
     fclose(fpIn);


### PR DESCRIPTION
- Add a -do-not-transform option wich allow to not apply translation and/or rotation when converting a *.3d or *.hf file to an other file format. Usefull to center a terrain tile in Blender or to understand how to create rotors, gears, ailerons, and other moving parts.
- Fix a bug in *.obj to *.hf conversion which cause to produce a bottom/top flipped height field tga image.
- Try to automatically retrieve full texture path in *.hf to *.obj conversion.
- Fix a bug in time stamp name for files stored in ~/.local/share/v3dconverter/ during file format conversion.
- Fix some new compilation warnings. I suppose that gcc -Wall option configuration has changed...
- Update readme.txt file.
- Version number is now 0.3.3.