### PR TITLE
Add a link back to GitHub

### DIFF
--- a/extra/sar2.appdata.xml
+++ b/extra/sar2.appdata.xml
@@ -54,6 +54,7 @@
     </release>
   </releases>
   <url type="homepage">https://searchandrescue2.github.io/sar2/</url>
+  <url type="vcs-browser">https://github.com/SearchAndRescue2/sar2/</url>
   <url type="bugtracker">https://github.com/SearchAndRescue2/sar2/issues</url>
   <content_rating type="oars-1.1"/>
 </component>


### PR DESCRIPTION
To resolve https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-vcs-browser-url
